### PR TITLE
BP-1171: New node registered with same name

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+- [Incident_Id_XXX](Incident_Id_XXX_JIRA_URL) / [RnD_Id_XXX](RnD_Id_XXX_JIRA_URL): Jira Ticket Title
+  - Packages updated:
+    - movai_package_foo (old_version -> new_version):
+      - new_version_1:
+        - <description of what changed, this is a free section, place here the info you see fit>
+      - new_version_2:
+        - <description of what changed, this is a free section, place here the info you see fit>
+  - Limitations:
+    - <limitation 1>
+    - <delete limitation section if not exists>
+  - Update steps required:
+    - <step 1>
+    - <delete update section if not exists>
+  - Notes:
+    - <behaviour changes or other information>
+    - <delete notes section if not exists>
+
+- [RnD_Id_XXX](RnD_Id_XXX_JIRA_URL): Jira Ticket Title
+  - Packages updated:
+    - movai_package_foo (old_version -> new_version):
+      - new_version_1:
+        - <description of what changed, this is a free section, place here the info you see fit>
+      - new_version_2:
+        - <description of what changed, this is a free section, place here the info you see fit>
+  - Limitations:
+    - <limitation 1>
+    - <delete limitation section if not exists>
+  - Update steps required:
+    - <step 1>
+    - <delete update section if not exists>
+  - Notes:
+    - <behavior changes or other information>
+    - <delete notes section if not exists>

--- a/.github/workflows/DeployOnGitRelease.yml
+++ b/.github/workflows/DeployOnGitRelease.yml
@@ -1,0 +1,23 @@
+name: "Deploy - To Nexus On Github Release"
+on:
+  release:
+    types: [released]
+
+jobs:
+  Release-Ros-Component:
+    uses: MOV-AI/.github/.github/workflows/ros-workflow.yml@v2
+    with:
+      release: 'true'
+      ros_distro: '["noetic"]'
+    secrets:
+      auto_commit_user: ${{ secrets.RAISE_BOT_COMMIT_USER }}
+      auto_commit_mail: ${{ secrets.RAISE_BOT_COMMIT_MAIL }}
+      auto_commit_pwd: ${{ secrets.RAISE_BOT_COMMIT_PASSWORD }}
+      registry_user: ${{ secrets.PORTUS_APP_USER }}
+      registry_password: ${{ secrets.PORTUS_APP_TOKEN }}
+      nexus_publisher_user: ${{ secrets.NEXUS_PUBLISHER_USR }}
+      nexus_publisher_password: ${{ secrets.NEXUS_PUBLISHER_PWD }}
+      aws_sqs_rosdep_access_key: ${{ secrets.AWS_SQS_ROSDEP_ACCESS_KEY }}
+      aws_sqs_rosdep_secret_access_key: ${{ secrets.AWS_SQS_ROSDEP_SECRET_ACCESS_KEY }}
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
+      sonar_token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/DeployOnMergeMain.yml
+++ b/.github/workflows/DeployOnMergeMain.yml
@@ -1,0 +1,28 @@
+name: "Deploy - On branch main/release Push"
+on:
+  push:
+    branches:
+      - noetic-devel
+      - main
+      - 'releases/**'
+
+jobs:
+  Deploy:
+    uses: MOV-AI/.github/.github/workflows/ros-workflow.yml@v2
+    with:
+      deploy: 'true'
+      ros_distro: '["noetic"]'
+      propagate_to_projects: false
+      install_test: true
+    secrets:
+      auto_commit_user: ${{ secrets.RAISE_BOT_COMMIT_USER }}
+      auto_commit_mail: ${{ secrets.RAISE_BOT_COMMIT_MAIL }}
+      auto_commit_pwd: ${{ secrets.RAISE_BOT_COMMIT_PASSWORD }}
+      registry_user: ${{ secrets.PORTUS_APP_USER }}
+      registry_password: ${{ secrets.PORTUS_APP_TOKEN }}
+      nexus_publisher_user: ${{ secrets.NEXUS_PUBLISHER_USR }}
+      nexus_publisher_password: ${{ secrets.NEXUS_PUBLISHER_PWD }}
+      aws_sqs_rosdep_access_key: ${{ secrets.AWS_SQS_ROSDEP_ACCESS_KEY }}
+      aws_sqs_rosdep_secret_access_key: ${{ secrets.AWS_SQS_ROSDEP_SECRET_ACCESS_KEY }}
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
+      sonar_token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/TestOnPR.yml
+++ b/.github/workflows/TestOnPR.yml
@@ -1,0 +1,28 @@
+name: "CI - On main/dev/release branches"
+on:
+  pull_request:
+    branches:
+      - noetic-devel
+      - main
+      - 'releases/**'
+
+jobs:
+  CI:
+    uses: MOV-AI/.github/.github/workflows/ros-workflow.yml@v2
+    with:
+      deploy: 'false'
+      ros_distro: '["noetic"]'
+      install_test: true
+    secrets:
+      auto_commit_user: ${{ secrets.RAISE_BOT_COMMIT_USER }}
+      auto_commit_mail: ${{ secrets.RAISE_BOT_COMMIT_MAIL }}
+      auto_commit_pwd: ${{ secrets.RAISE_BOT_COMMIT_PASSWORD }}
+      registry_user: ${{ secrets.PORTUS_APP_USER }}
+      registry_password: ${{ secrets.PORTUS_APP_TOKEN }}
+      nexus_publisher_user: ${{ secrets.NEXUS_PUBLISHER_USR }}
+      nexus_publisher_password: ${{ secrets.NEXUS_PUBLISHER_PWD }}
+      aws_sqs_rosdep_access_key: ${{ secrets.AWS_SQS_ROSDEP_ACCESS_KEY }}
+      aws_sqs_rosdep_secret_access_key: ${{ secrets.AWS_SQS_ROSDEP_SECRET_ACCESS_KEY }}
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
+      sonar_token: ${{ secrets.SONAR_TOKEN }}
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+REGISTRY="registry.cloud.mov.ai"
+ENV="qa"
+IMAGE_NAME="flow-initiator-noetic"
+IMAGE_TAG="local"
+DOCKER_IMAGE="registry.cloud.mov.ai/qa/ros-buildtools-noetic:v2.1.1"
+
+
+deb:
+	DOCKER_IMAGE="registry.cloud.mov.ai/qa/ros-buildtools-noetic:v2.1.1"; \
+	container_id=$$(docker run -td -v "$$(pwd)":/src "$$DOCKER_IMAGE" sh) && \
+	echo "Running in $$container_id" && \
+	docker exec -t -uroot "$$container_id" bash -c " \
+    sudo apt update ; \
+    sudo apt install -y mobros=2.1.1.5 ; \
+    mkdir /opt/mov.ai/user/cache/ros/src/ ; \
+    ln -s /src /opt/mov.ai/user/cache/ros/src/ ; \
+    mobros raise --workspace=/src ; \
+    sudo mobros install-build-dependencies --workspace="/src" ; \
+    mobros build --mode release ; \
+    export MOVAI_OUTPUT_DIR="$(pwd)/artifacts" ; \
+    mobros pack --workspace="/src" --mode release \
+    " || true; \
+	docker rm -f "$$container_id"

--- a/tools/rosmaster/src/rosmaster/registrations.py
+++ b/tools/rosmaster/src/rosmaster/registrations.py
@@ -72,8 +72,7 @@ class NodeRef(object):
         @return: True if node has no active registrations
         """
         return sum((len(x) for x in
-                    [self.param_subscriptions, 
-                     self.topic_subscriptions,
+                    [self.topic_subscriptions,
                      self.topic_publications,
                      self.services,])) == 0
     


### PR DESCRIPTION
This pull request adds MOVAI CI/CD workflows and documentation for the repositiry as well as a patch to fix the issue [BP-1171: New node registered with same name](https://github.com/MOV-AI/containers-ros-master/pull/41)

**CI/CD Workflow Enhancements:**

* Added `.github/workflows/TestOnPR.yml` to enable automated CI tests on pull requests targeting main, noetic-devel, and release branches using the shared ROS workflow.
* Added `.github/workflows/DeployOnMergeMain.yml` to automate deployment on pushes to main, noetic-devel, and release branches, leveraging the shared ROS workflow.
* Added `.github/workflows/DeployOnGitRelease.yml` to automate deployment to Nexus on GitHub releases, using the shared ROS workflow and appropriate secrets.


**Code Patch:**

* Simplified the `is_empty` method in `rosmaster/registrations.py` by removing the unused `param_subscriptions` from the registration check.